### PR TITLE
Fix profit handling and add validation

### DIFF
--- a/IMPLEMENTATION_PLAN.md
+++ b/IMPLEMENTATION_PLAN.md
@@ -38,7 +38,7 @@ This document outlines the implementation plan for building a ML system to predi
 - **Market Data**: Price, volume, volatility from IBKR
 - **VIX**: Level, change, regime classification
 - **Technical**: RSI, moving averages, momentum
-- **Trade-specific**: Strategy, premium, risk/reward
+ - **Trade-specific**: Strategy, premium_normalized, risk_reward_ratio
 
 #### Models
 - XGBoost baseline (primary)

--- a/PHASE1_SUMMARY.md
+++ b/PHASE1_SUMMARY.md
@@ -96,7 +96,7 @@ By Symbol:
 2. **Price-Based** (~40): close, SMA, momentum, volatility, RSI for each symbol
 3. **VIX** (7): level, SMA, change, regime indicators
 4. **Strategy** (4): One-hot encoded (now includes Sonar)
-5. **Trade** (10): premium, risk, reward, ratios
+5. **Trade** (8): premium_normalized and risk_reward_ratio (raw risk/reward columns removed)
 
 ## How to Complete Phase 1 (Updated Steps)
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cp data/processed_optimized_v2/magic8_trades_complete.csv data/normalized/normal
 ### Step 3: Run Optimized ML Pipeline
 ```bash
 # Feature engineering - now runs in 2-5 minutes!
-python src/phase1_data_preparation.py
+python src/phase1_data_preparation.py  # includes profit validation
 
 # Train model
 python src/models/xgboost_baseline.py
@@ -82,7 +82,7 @@ python src/models/xgboost_baseline.py
 2. **Price-Based** (~40): close, SMA, momentum, volatility, RSI per symbol
 3. **VIX** (7): level, SMA, change, regime
 4. **Strategy** (4): one-hot encoded
-5. **Trade** (10): premium, risk, reward, ratios
+5. **Trade** (8): premium_normalized and risk_reward_ratio (raw risk/reward columns removed)
 
 ## 📁 Key Scripts
 

--- a/process_magic8_data_optimized_v2.py
+++ b/process_magic8_data_optimized_v2.py
@@ -365,6 +365,7 @@ class Magic8DataProcessorOptimized:
                     'stop': self.safe_float(row.get('Stop')),
                     'raw': self.safe_float(row.get('Raw')),
                     'managed': self.safe_float(row.get('Managed')),
+                    'profit': self.safe_float(row.get('Raw') or row.get('raw')),
                     'trade_description': self.clean_string(row.get('Trade', '')),
                     'source_file': 'profit',
                     'format_year': 2024,

--- a/src/phase1_data_preparation.py
+++ b/src/phase1_data_preparation.py
@@ -21,6 +21,7 @@ import os
 import logging
 import pytz
 import time
+from validate_profit_coverage import validate_profit_data
 
 class Phase1DataPreparation:
     def __init__(self, data_path='data/normalized/normalized_aggregated.csv', 
@@ -409,19 +410,25 @@ class Phase1DataPreparation:
         start_time = time.time()
         self.logger.info("Creating target variable from profit data...")
         
-        # Use the 'profit' column directly since we don't have Raw profit
-        if 'prof_profit' in self.df.columns:
-            # Profit > 0 = Win (1), Profit <= 0 = Loss (0)
-            self.df['target'] = (self.df['prof_profit'] > 0).astype(int)
-            
-            # Log statistics
-            non_null_count = self.df['target'].notna().sum()
-            self.logger.info(f"Created target from prof_profit: {non_null_count} records")
-            self.logger.info(f"Target distribution: {self.df['target'].value_counts().to_dict()}")
-            self.logger.info(f"Win rate: {self.df['target'].mean():.2%}")
-        else:
+        profit_sources = ['prof_profit', 'raw', 'managed', 'profit_final']
+        profit_col = None
+        for col in profit_sources:
+            if col in self.df.columns and self.df[col].notna().any():
+                profit_col = col
+                break
+
+        if not profit_col:
             raise ValueError("No profit column found for creating target variable!")
-        
+
+        self.logger.info(f"Using '{profit_col}' column for target creation")
+        non_null_count = self.df[profit_col].notna().sum()
+        self.logger.info(f"Non-null profit values: {non_null_count}")
+
+        self.df['target'] = (self.df[profit_col] > 0).astype(int)
+
+        self.logger.info(f"Target distribution: {self.df['target'].value_counts().to_dict()}")
+        self.logger.info(f"Win rate: {self.df['target'].mean():.2%}")
+
         self._log_time(start_time, "Target variable creation")
         return self
         
@@ -456,7 +463,7 @@ class Phase1DataPreparation:
         # Original features to keep (if they exist)
         original_features = [
             'pred_predicted', 'pred_price', 'pred_difference',
-            'prof_premium', 'prof_risk', 'prof_reward'
+            'prof_premium'
         ]
         
         # Add optional features if they exist
@@ -487,17 +494,35 @@ class Phase1DataPreparation:
         # Remove rows without target
         valid_data = self.df[self.df['target'].notna()].copy()
         
-        # Calculate split points
+        # Calculate temporal cut points
         n_samples = len(valid_data)
-        train_end = int(n_samples * (1 - test_size - val_size))
-        val_end = int(n_samples * (1 - test_size))
+        train_val_end = int(n_samples * (1 - test_size))
+
+        train_val = valid_data.iloc[:train_val_end]
+        test_data = valid_data.iloc[train_val_end:]
+
+        # Stratified split on the training portion for balanced classes
+        from sklearn.model_selection import train_test_split
+        train_data, val_data = train_test_split(
+            train_val,
+            test_size=val_size / (1 - test_size),
+            stratify=train_val['target'],
+            random_state=42,
+            shuffle=True,
+        )
         
-        # Split temporally
-        train_data = valid_data.iloc[:train_end]
-        val_data = valid_data.iloc[train_end:val_end]
-        test_data = valid_data.iloc[val_end:]
-        
-        self.logger.info(f"Train: {len(train_data)}, Val: {len(val_data)}, Test: {len(test_data)}")
+        self.logger.info(
+            f"Train: {len(train_data)}, Val: {len(val_data)}, Test: {len(test_data)}"
+        )
+        self.logger.info(
+            f"Class distribution - Train: {train_data['target'].value_counts().to_dict()}"
+        )
+        self.logger.info(
+            f"Class distribution - Val: {val_data['target'].value_counts().to_dict()}"
+        )
+        self.logger.info(
+            f"Class distribution - Test: {test_data['target'].value_counts().to_dict()}"
+        )
         
         # Save splits
         os.makedirs('data/phase1_processed', exist_ok=True)
@@ -556,7 +581,10 @@ class Phase1DataPreparation:
         
         # Create target
         self.create_target_variable()
-        
+
+        # Validate profit coverage and class balance
+        validate_profit_data(self.df)
+
         # Select features
         self.select_features()
         

--- a/validate_profit_coverage.py
+++ b/validate_profit_coverage.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def validate_profit_data(df: pd.DataFrame) -> None:
+    """Validate profit coverage and monthly win distribution.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        DataFrame after target creation. Must contain 'interval_datetime',
+        a profit column and 'target'.
+    """
+    if 'interval_datetime' not in df.columns:
+        raise ValueError("DataFrame missing 'interval_datetime' column")
+    if 'target' not in df.columns:
+        raise ValueError("DataFrame must have a 'target' column for win checks")
+
+    df = df.copy()
+    df['month'] = pd.to_datetime(df['interval_datetime']).dt.to_period('M')
+
+    profit_cols = [c for c in df.columns if c in ['prof_profit', 'raw', 'managed', 'profit_final']]
+    profit_col = profit_cols[0] if profit_cols else None
+
+    if not profit_col:
+        logger.warning("No profit column found for validation")
+        return
+
+    monthly_counts = df.groupby('month')[profit_col].apply(lambda x: x.notna().sum())
+    logger.info("Profit coverage by month:\n%s", monthly_counts.to_string())
+
+    monthly_wins = df.groupby('month')['target'].sum()
+    zero_win_months = monthly_wins[monthly_wins == 0]
+    if not zero_win_months.empty:
+        logger.error("Months with zero wins detected: %s", list(zero_win_months.index.astype(str)))
+        raise ValueError("Data validation failed: months with zero wins")


### PR DESCRIPTION
## Summary
- compute profit from `Raw` column for 2024-format files
- create target from first available profit column
- validate profit coverage and class balance
- remove risk and reward features
- stratify train/val split after temporal partition
- document new behaviour in README and summaries

## Testing
- `pytest -q` *(fails: FileNotFoundError for data paths)*
- `flake8` *(fails: many style violations)*

------
https://chatgpt.com/codex/tasks/task_e_6862fae2cb1c833085effcdbf46ed162