### PR TITLE
Fix profit parsing across formats

### DIFF
--- a/PROJECT_KNOWLEDGE_BASE.md
+++ b/PROJECT_KNOWLEDGE_BASE.md
@@ -114,6 +114,10 @@ The Magic8 Accuracy Predictor is a machine learning system designed to predict t
   - `timestamp` → `interval_datetime`
   - etc.
 
+### 3b. Profit Column Variations
+- **Problem**: Late‑2023 CSV files dropped the `Profit` column and use `Raw` or `Managed` instead.
+- **Solution**: The processor now falls back to `Profit`, then `Raw`, then `Managed` so wins are captured.
+
 ### 4. Time-Series Merge Optimization
 - **Problem**: Nested loop with point-by-point lookups (O(n×m))
 - **Solution**: Use `pd.merge_asof()` for efficient time-based joins

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ python process_magic8_data_optimized_v2.py
 cp data/processed_optimized_v2/magic8_trades_complete.csv data/normalized/normalized_aggregated.csv
 ```
 
+The processor automatically detects the available profit column. If your CSVs
+don't have a `Profit` column (December 2023 onward) it will fall back to
+`Raw` or `Managed`.
+
 ### Step 3: Run Optimized ML Pipeline
 ```bash
 # Feature engineering - now runs in 2-5 minutes!

--- a/tests/test_profit_parsing.py
+++ b/tests/test_profit_parsing.py
@@ -1,0 +1,40 @@
+import io
+from datetime import datetime
+from pathlib import Path
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from process_magic8_data_optimized_v2 import Magic8DataProcessorOptimized
+
+
+def create_processor():
+    return Magic8DataProcessorOptimized(source_path='.', output_path='tests/tmp', batch_size=1000)
+
+
+def test_profit_parsing_2023():
+    csv_data = "Day,Hour,Symbol,Price,Name,Predicted,Closed,Risk,Reward,Premium,Stop,Raw,Managed,Trade,Profit\n2023-12-01,10:00,SPX,4500,Iron Condor,0,0,0,0,0,0,1,2,desc,5"
+    proc = create_processor()
+    proc.process_profit_2023_format(io.StringIO(csv_data), datetime(2023, 12, 1), Path('file.csv'))
+    assert proc.current_batch[0]['profit'] == 5
+
+
+def test_profit_parsing_2024():
+    csv_data = "Day,Hour,Symbol,Price,Name,Predicted,Closed,Risk,Reward,Premium,Stop,Raw,Managed,Trade\n2024-01-02,09:40,SPX,4500,Iron Condor,0,0,0,0,0,0,5,2,desc"
+    proc = create_processor()
+    proc.process_profit_2024_format(io.StringIO(csv_data), datetime(2024, 1, 2), Path('file.csv'))
+    assert proc.current_batch[0]['profit'] == 5
+
+
+def test_profit_parsing_2025():
+    csv_data = "Date,Hour,Symbol,Price,Name,Predicted,Low,High,Closing,Risk,ExpectedPremium,ActualPremium,Raw,Managed,Trade,Profit,TotalProfit\n2025-02-03,10:30,SPX,4500,Iron Condor,0,0,0,0,0,0,0,1,2,desc,7,7"
+    proc = create_processor()
+    proc.process_profit_2025_format(io.StringIO(csv_data), datetime(2025, 2, 3), Path('file.csv'))
+    assert proc.current_batch[0]['profit'] == 7
+
+
+def test_missing_profit_logged():
+    csv_data = "Day,Hour,Symbol,Price,Name,Predicted,Closed,Risk,Reward,Premium,Stop,Trade\n2024-01-02,09:40,SPX,4500,Iron Condor,0,0,0,0,0,0,desc"
+    proc = create_processor()
+    proc.process_profit_2024_format(io.StringIO(csv_data), datetime(2024, 1, 2), Path('file.csv'))
+    assert proc.quality_issues['missing_profit']


### PR DESCRIPTION
## Summary
- support Profit/Raw/Managed columns for all formats
- log rows missing profit values
- include profit from trades files
- document profit column variations in README and knowledge base
- add regression tests for profit column handling

## Testing
- `pytest tests/test_profit_parsing.py -q`
- `pytest -q` *(fails: FileNotFoundError: [Errno 2] No such file or directory: 'data/ibkr')*

------
https://chatgpt.com/codex/tasks/task_e_686334d5c65c8330b03292834a536de2