### PR TITLE
Enable companion provider and align features

### DIFF
--- a/QUICK_START_GUIDE.md
+++ b/QUICK_START_GUIDE.md
@@ -60,8 +60,7 @@ python quick_start.py
 # Set up Magic8-Companion API
 python setup_companion_api.py
 
-# Update config/config.yaml:
-# Change primary: "mock" to primary: "companion"
+# Configuration now defaults to the companion provider
 ```
 
 ### Option 3: Direct IBKR (Standalone)

--- a/README.md
+++ b/README.md
@@ -154,10 +154,26 @@ magic8-accuracy-predictor/
    ```
 
 3. **Integration Components**
-   - WebSocket connection to Magic8
-   - IBKR API for market data
-   - Redis for feature caching
-   - REST API for predictions
+ - WebSocket connection to Magic8
+  - IBKR API for market data
+  - Redis for feature caching
+  - REST API for predictions
+
+### Enabling Magic8-Companion Data API
+1. In the `Magic8-Companion` repository add the FastAPI endpoints:
+   ```bash
+   cd /path/to/Magic8-Companion
+   python ../magic8-accuracy-predictor/setup_companion_api.py
+   ```
+2. Start the companion with the API enabled:
+   ```bash
+   export M8C_ENABLE_DATA_API=true
+   python -m magic8_companion
+   ```
+3. Verify the API is running:
+   ```bash
+   curl http://localhost:8765/health
+   ```
 
 4. **Monitoring & Feedback**
    - Track prediction accuracy

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -6,15 +6,15 @@ system:
 
 # Data source configuration
 data_source:
-  primary: "mock"  # Using mock for testing without dependencies
-  fallback: "standalone"     # Optional fallback if primary fails
+  primary: "companion"  # Use Magic8-Companion API by default
+  fallback: "standalone"     # Optional fallback if companion fails
   
   mock:
     enabled: true
     # Mock provider requires no configuration
     
   companion:
-    enabled: false  # Disabled for testing
+    enabled: true
     base_url: "http://localhost:8765"
     timeout: 5
     retry_attempts: 3

--- a/quick_start.py
+++ b/quick_start.py
@@ -59,6 +59,11 @@ def check_prerequisites():
         logger.warning("✗ Config file missing")
     else:
         logger.info("✓ Config file found")
+        import yaml
+        with open('config/config.yaml') as f:
+            cfg = yaml.safe_load(f)
+        provider = cfg.get('data_source', {}).get('primary', 'unknown')
+        logger.info(f"✓ Primary data provider: {provider}")
     
     # Check for data providers
     if not Path('src/data_providers').exists():

--- a/tests/test_feature_alignment.py
+++ b/tests/test_feature_alignment.py
@@ -1,0 +1,56 @@
+import json
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import types
+
+base_module = types.ModuleType('src.data_providers.base_provider')
+
+class BaseDataProvider:
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def is_connected(self) -> bool:
+        return True
+
+base_module.BaseDataProvider = BaseDataProvider
+sys.modules['src.data_providers'] = types.ModuleType('src.data_providers')
+sys.modules['src.data_providers.base_provider'] = base_module
+
+from src.feature_engineering.real_time_features import RealTimeFeatureGenerator
+
+class DummyProvider:
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self):
+        pass
+
+    async def is_connected(self) -> bool:
+        return True
+
+    async def get_price_data(self, symbol: str, bars: int = 100):
+        return []
+
+    async def get_current_price(self, symbol: str):
+        return {"last": 0}
+
+    async def get_vix_data(self):
+        return {"last": 0}
+
+    async def get_price_snapshot(self, symbol: str):
+        return {}
+
+
+def test_feature_order_matches_model():
+    path = Path("data/phase1_processed/feature_info.json")
+    info = json.loads(path.read_text())
+    provider = DummyProvider()
+    gen = RealTimeFeatureGenerator(provider, feature_info_path=str(path))
+    assert len(gen.feature_order) == info["n_features"]


### PR DESCRIPTION
## Summary
- load feature order from feature_info.json in real-time generator
- ensure feature order count matches via new unit test
- switch default data source to Magic8-Companion
- show active provider in `quick_start.py`
- document how to enable the Companion API
- update Quick Start guide for new default

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68640d9d1d1483309d114478979de111