### PR TITLE
Fix wrapper path in XGBoost baseline

### DIFF
--- a/src/models/xgboost_baseline.py
+++ b/src/models/xgboost_baseline.py
@@ -21,7 +21,7 @@ import seaborn as sns
 import shutil
 
 # Import the model wrapper
-from model_wrappers import XGBoostModelWrapper
+from src.models.model_wrappers import XGBoostModelWrapper
 
 class XGBoostBaseline:
     def __init__(self, config_path=None):


### PR DESCRIPTION
## Summary
- update import path for `XGBoostModelWrapper` in `xgboost_baseline.py`
- run model conversion script after updating path
- run automated tests

## Testing
- `python prepare_model_for_predictor.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6864275bc3e0833090759ac3fcb28b41