### PR TITLE
Implement symbol grouping and schema doc

### DIFF
--- a/REVAMP_ACTION_ITEMS.md
+++ b/REVAMP_ACTION_ITEMS.md
@@ -19,7 +19,7 @@
 **Deliverables**:
 1. Symbol-specific data files (SPX_trades.csv, NDX_trades.csv, etc.)
 2. Profit scale analysis report showing 76x differences
-3. Model grouping recommendations
+3. Model grouping recommendations ✅
 
 ## 📊 Data Schema After Fix
 
@@ -53,8 +53,9 @@
 ### For Data Processing Fix:
  - [x] All 3 sheets merged correctly
  - [x] No duplicate trades
- - [x] Format_year matches actual dates
- - [ ] All 40+ columns captured
+- [x] Format_year matches actual dates
+ - [x] All 40+ columns captured
+- [x] Data schema documented
  - [x] Symbol-specific files generated
 
 ### For Model Architecture:

--- a/REVAMP_SUMMARY.md
+++ b/REVAMP_SUMMARY.md
@@ -21,8 +21,9 @@ The data processing is **fundamentally incomplete**:
 - Create symbol-specific data splits
 - Fix format_year bug
 - Analyze profit scales by symbol
- - **Progress**: Processor now merges all sheets with duplicate detection and
+- **Progress**: Processor now merges all sheets with duplicate detection and
    timestamp validation
+- **Progress**: Data schema documented and model grouping logic implemented
 
 ### Phase 1: Feature Engineering [2-3 days]
 - Extract Magic8's prediction indicators

--- a/docs/DATA_SCHEMA_COMPLETE.md
+++ b/docs/DATA_SCHEMA_COMPLETE.md
@@ -1,0 +1,69 @@
+# Magic8 Trade Data Schema
+
+This document lists all columns produced by `process_magic8_data_optimized_v2.py` after the Phase 0 rebuild. The schema consolidates the **profit**, **trades** and **delta** sheets and is used for feature engineering in later phases.
+
+## Identity Fields
+- `date`
+- `time`
+- `timestamp`
+- `symbol`
+- `strategy`
+
+## Profit Sheet Columns
+- `price`
+- `premium`
+- `predicted`
+- `closed`
+- `expired`
+- `risk`
+- `reward`
+- `ratio`
+- `profit`
+- `win`
+
+## Trades Sheet Columns
+- `source`
+- `expected_move`
+- `low`
+- `high`
+- `target1`
+- `target2`
+- `predicted_trades`
+- `closing`
+- `strike1`
+- `direction1`
+- `type1`
+- `bid1`
+- `ask1`
+- `mid1`
+- `strike2`
+- `direction2`
+- `type2`
+- `bid2`
+- `ask2`
+- `mid2`
+- `strike3`
+- `direction3`
+- `type3`
+- `bid3`
+- `ask3`
+- `mid3`
+- `strike4`
+- `direction4`
+- `type4`
+- `bid4`
+- `ask4`
+- `mid4`
+
+## Delta Sheet Columns
+- `call_delta`
+- `put_delta`
+- `predicted_delta`
+- `short_term`
+- `long_term`
+- `closing_delta`
+
+## Metadata
+- `trade_description`
+- `source_file`
+- `format_year`

--- a/src/feature_engineering/magic8_features.py
+++ b/src/feature_engineering/magic8_features.py
@@ -24,18 +24,33 @@ class Magic8FeatureEngineer:
         pass
 
     def add_strike_features(self, df: pd.DataFrame) -> pd.DataFrame:
-        # Placeholder for strike structure features
+        """Create features describing the strike layout."""
         strike_cols = ['strike1', 'strike2', 'strike3', 'strike4']
         if all(col in df.columns for col in strike_cols):
-            df['strike_distance_pct'] = (df['strike4'] - df['strike1']) / df['strike1'].abs()
+            df['strike_distance_pct'] = (df['strike4'] - df['strike1']) / (df['strike1'].abs() + 1e-9)
+            df['avg_strike'] = df[strike_cols].mean(axis=1)
+            df['strike_width'] = df['strike4'] - df['strike1']
         return df
 
     def add_delta_features(self, df: pd.DataFrame) -> pd.DataFrame:
         if 'call_delta' in df.columns and 'put_delta' in df.columns:
             df['delta_diff'] = df['call_delta'] - df['put_delta']
+        if 'predicted_delta' in df.columns:
+            df['delta_error'] = df['predicted_delta'] - df[['call_delta', 'put_delta']].mean(axis=1)
+        if 'short_term' in df.columns and 'long_term' in df.columns:
+            df['term_structure'] = df['short_term'] - df['long_term']
+        return df
+
+    def add_microstructure_features(self, df: pd.DataFrame) -> pd.DataFrame:
+        """Add simple market microstructure features from bid/ask prices."""
+        if 'bid1' in df.columns and 'ask1' in df.columns:
+            df['spread1'] = df['ask1'] - df['bid1']
+        if 'bid2' in df.columns and 'ask2' in df.columns:
+            df['spread2'] = df['ask2'] - df['bid2']
         return df
 
     def engineer(self, df: pd.DataFrame) -> pd.DataFrame:
         df = self.add_strike_features(df)
         df = self.add_delta_features(df)
+        df = self.add_microstructure_features(df)
         return df

--- a/src/symbol_analyzer.py
+++ b/src/symbol_analyzer.py
@@ -1,0 +1,38 @@
+"""Utilities for analyzing symbol-specific profit patterns."""
+from typing import Dict
+
+class SymbolSpecificAnalyzer:
+    """Analyze profit scales and recommend model grouping."""
+
+    def analyze_profit_scales(self, symbol_stats: Dict) -> Dict:
+        """Group symbols into large, medium and small profit scales."""
+        profit_groups = {
+            'large_scale': [],
+            'medium_scale': [],
+            'small_scale': []
+        }
+        for symbol, stats in symbol_stats.items():
+            butterfly_profit = stats.get('profit_by_strategy', {}).get('Butterfly', {}).get('avg_profit', 0)
+            if abs(butterfly_profit) > 1000:
+                profit_groups['large_scale'].append(symbol)
+            elif abs(butterfly_profit) > 100:
+                profit_groups['medium_scale'].append(symbol)
+            else:
+                profit_groups['small_scale'].append(symbol)
+        return profit_groups
+
+    def recommend_model_grouping(self, profit_groups: Dict) -> Dict:
+        """Recommend model grouping strategy based on profit scales."""
+        recommendations = {
+            'separate_models': list(profit_groups.get('large_scale', [])),
+            'grouped_models': {},
+            'unified_model': list(profit_groups.get('small_scale', []))
+        }
+
+        medium = profit_groups.get('medium_scale', [])
+        if len(medium) > 3:
+            recommendations['grouped_models']['medium_scale'] = medium
+        else:
+            recommendations['separate_models'].extend(medium)
+
+        return recommendations

--- a/symbol_analysis_report.py
+++ b/symbol_analysis_report.py
@@ -4,6 +4,7 @@ import pandas as pd
 import json
 import os
 from typing import Dict
+from src.symbol_analyzer import SymbolSpecificAnalyzer
 
 
 def generate_symbol_report(input_file: str, output_dir: str) -> Dict:
@@ -36,6 +37,15 @@ def generate_symbol_report(input_file: str, output_dir: str) -> Dict:
     out_file = os.path.join(output_dir, 'symbol_profit_report.json')
     with open(out_file, 'w') as f:
         json.dump(report, f, indent=2)
+
+    # Recommend model grouping using SymbolSpecificAnalyzer
+    analyzer = SymbolSpecificAnalyzer()
+    groups = analyzer.analyze_profit_scales(report)
+    recommendations = analyzer.recommend_model_grouping(groups)
+
+    with open(os.path.join(output_dir, 'model_grouping.json'), 'w') as f:
+        json.dump(recommendations, f, indent=2)
+
     return report
 
 

--- a/tests/test_symbol_analyzer.py
+++ b/tests/test_symbol_analyzer.py
@@ -1,0 +1,13 @@
+from src.symbol_analyzer import SymbolSpecificAnalyzer
+
+def test_recommend_model_grouping():
+    analyzer = SymbolSpecificAnalyzer()
+    groups = {
+        'large_scale': ['NDX', 'RUT'],
+        'medium_scale': ['SPX', 'SPY', 'QQQ', 'XSP'],
+        'small_scale': ['AAPL']
+    }
+    rec = analyzer.recommend_model_grouping(groups)
+    assert 'NDX' in rec['separate_models']
+    assert rec['grouped_models']['medium_scale'] == ['SPX', 'SPY', 'QQQ', 'XSP']
+    assert rec['unified_model'] == ['AAPL']


### PR DESCRIPTION
## Summary
- add SymbolSpecificAnalyzer with model grouping logic
- augment Magic8 feature engineering with delta and microstructure features
- document complete trade data schema
- update symbol analysis script to output grouping recommendations
- note progress in REVAMP summary/action items
- add basic unit test for SymbolSpecificAnalyzer

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68680a8147a08330aa835ba55bfb1a6e