### PR TITLE
Add enhanced parser integration

### DIFF
--- a/COMPLETE_INTEGRATION_DOCS.md
+++ b/COMPLETE_INTEGRATION_DOCS.md
@@ -1,0 +1,24 @@
+# Complete Integration Docs
+
+## 11. Enhanced ML Predictor Integration
+
+This update introduces an improved parser used by DiscordTrading. The new
+`parse_magic8_message_enhanced` function extracts prediction lines and trade
+instructions from raw Discord messages and calculates risk/reward for each
+instruction. Use it in place of the older parser.
+
+### Usage
+
+1. Import the parser in your DiscordTrading bot:
+   ```python
+   from magic8_integration import parse_magic8_message_enhanced
+   ```
+2. When a message is received, call:
+   ```python
+   parsed_message = parse_magic8_message_enhanced(content)
+   ```
+3. The returned dictionary contains `predictions` and a list of `trades` with
+   risk/reward details.
+
+This function wraps the logic from `src/enhanced_discord_parser.py` and keeps
+trade analysis in a single place for easier integration.

--- a/REMAINING_IMPLEMENTATION.md
+++ b/REMAINING_IMPLEMENTATION.md
@@ -1,0 +1,12 @@
+# Remaining Implementation
+
+The following tasks were completed to finalize the enhanced parser
+integration:
+
+- Added `parse_magic8_message_enhanced` in `magic8_integration.py` with risk/
+  reward calculations.
+- Created unit tests (`test_magic8_integration_parser.py`) verifying the new
+  function.
+- Documented usage in `COMPLETE_INTEGRATION_DOCS.md` under section 11.
+
+No further implementation items remain for this feature.

--- a/magic8_integration.py
+++ b/magic8_integration.py
@@ -1,0 +1,87 @@
+import re
+from typing import Dict, List
+
+from src.risk_reward_calculator import RiskRewardCalculator
+
+
+def _extract_number(line: str) -> float | None:
+    match = re.search(r"[-+]?\d*\.?\d+", line.split(":")[-1])
+    return float(match.group()) if match else None
+
+
+def _parse_trade_instruction(line: str) -> Dict | None:
+    action_match = re.search(r"\b(BUY|SELL)\b", line, re.IGNORECASE)
+    if not action_match:
+        return None
+    action = action_match.group(1).upper()
+
+    qty_match = re.search(r"\b(?:BUY|SELL)\s+(\d+)", line, re.IGNORECASE)
+    quantity = int(qty_match.group(1)) if qty_match else 1
+
+    strategy = None
+    for s in ["Butterfly", "Iron Condor", "Sonar", "Vertical"]:
+        if s in line:
+            strategy = s
+            break
+    if not strategy:
+        return None
+
+    strikes_match = re.search(r"(\d+(?:\.\d+)?(?:/\d+(?:\.\d+)?)+)", line)
+    strikes: List[float] = [float(x) for x in strikes_match.group(1).split("/")] if strikes_match else []
+
+    premium_match = re.search(r"for\s+([0-9]*\.?[0-9]+)", line)
+    premium = float(premium_match.group(1)) if premium_match else 0.0
+
+    option_type = "CALL"
+    if "Put" in line or "PUT" in line:
+        option_type = "PUT"
+
+    trade = {
+        "action": action,
+        "quantity": quantity,
+        "strategy": strategy,
+        "strikes": strikes,
+        "premium": premium,
+    }
+    if strategy == "Vertical":
+        trade["option_type"] = option_type
+    return trade
+
+
+def parse_magic8_message_enhanced(message: str) -> Dict:
+    """Parse Magic8 Discord messages and calculate risk/reward."""
+    result: Dict[str, Dict] = {"metadata": {}, "predictions": {}, "trades": []}
+    lines = message.split("\n")
+    calc = RiskRewardCalculator()
+
+    for line in lines:
+        if "Price:" in line:
+            result["predictions"]["current_price"] = _extract_number(line)
+        elif "Predicted Close:" in line:
+            result["predictions"]["predicted_close"] = _extract_number(line)
+        elif "Short term:" in line and "bias" not in line:
+            result["predictions"]["short_term"] = _extract_number(line)
+        elif "Long term:" in line and "bias" not in line:
+            result["predictions"]["long_term"] = _extract_number(line)
+        elif "Target 1:" in line:
+            result["predictions"]["target1"] = _extract_number(line)
+        elif "Target 2:" in line:
+            result["predictions"]["target2"] = _extract_number(line)
+        elif any(s in line for s in ["Butterfly", "Iron Condor", "Sonar", "Vertical"]):
+            trade = _parse_trade_instruction(line)
+            if trade:
+                if trade["strategy"] == "Butterfly":
+                    rr = calc.calculate_butterfly(trade["strikes"], trade["premium"], trade["action"], trade["quantity"])
+                elif trade["strategy"] in ["Iron Condor", "Sonar"]:
+                    rr = calc.calculate_iron_condor(trade["strikes"], trade["premium"], trade["action"], trade["quantity"])
+                else:
+                    rr = calc.calculate_vertical(
+                        trade["strikes"], trade["premium"], trade["action"], trade["option_type"], trade["quantity"]
+                    )
+                trade.update(rr)
+                if "short_term" in result["predictions"]:
+                    trade["short_term"] = result["predictions"]["short_term"]
+                if "long_term" in result["predictions"]:
+                    trade["long_term"] = result["predictions"]["long_term"]
+                result["trades"].append(trade)
+    return result

--- a/tests/test_magic8_integration_parser.py
+++ b/tests/test_magic8_integration_parser.py
@@ -1,0 +1,19 @@
+from magic8_integration import parse_magic8_message_enhanced
+
+sample_message = """Magic8 Alert SPX
+Price: 5860
+Predicted Close: 5875
+Short term: 0.65
+Long term: 0.7
+Target 1: 5885
+Target 2: 5895
+SELL 1 SPX 15 NOV 5850/5875/5900 Butterfly for 2.0 credit
+"""
+
+def test_parse_magic8_message_enhanced():
+    result = parse_magic8_message_enhanced(sample_message)
+    assert result["predictions"]["current_price"] == 5860.0
+    assert len(result["trades"]) == 1
+    trade = result["trades"][0]
+    assert trade["strategy"] == "Butterfly"
+    assert trade["risk_reward_ratio"] > 0


### PR DESCRIPTION
## Summary
- add `parse_magic8_message_enhanced` in new `magic8_integration.py`
- document parser usage in `COMPLETE_INTEGRATION_DOCS.md`
- track completed tasks in `REMAINING_IMPLEMENTATION.md`
- add unit test `test_magic8_integration_parser.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686ab673e79c8330be0b3909d61eb7c0