### PR TITLE
Fix target column name mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ python train_symbol_models.py data/symbol_specific models/individual data/symbol
 # - ... (model and features for each symbol)
 ```
 
+`prepare_symbol_data()` automatically adds a `target` column derived
+from the `profit` column (1 for wins, 0 for losses). The training
+scripts rely on this column for supervised learning.
+
 #### Step 4a: Analyze Profit Scales by Strategy
 ```bash
 # Analyze profit ranges for correct symbol grouping

--- a/docs/DATA_SCHEMA_COMPLETE.md
+++ b/docs/DATA_SCHEMA_COMPLETE.md
@@ -19,7 +19,7 @@ This document lists all columns produced by `process_magic8_data_optimized_v2.py
 - `reward`
 - `ratio`
 - `profit`
-- `win`
+- `target` - binary win/loss indicator derived from the `profit` column
 
 ## Trades Sheet Columns
 - `source`

--- a/src/models/symbol_strategy_trainer.py
+++ b/src/models/symbol_strategy_trainer.py
@@ -44,7 +44,13 @@ class SymbolStrategyModelTrainer:
                 logger.info("Training model for %s: %d samples", model_key, len(strat_df))
 
                 X = strat_df[feature_cols]
-                y = strat_df['win']
+                if 'target' not in strat_df.columns:
+                    raise ValueError("Missing 'target' column in training data")
+                y = strat_df['target']
+                if y.isna().all():
+                    raise ValueError(
+                        f"Target column for {model_key} contains only NaN values"
+                    )
 
                 X_train, X_test, y_train, y_test = train_test_split(
                     X, y, test_size=0.2, random_state=42, stratify=y


### PR DESCRIPTION
## Summary
- align `SymbolStrategyModelTrainer` to use `target` field
- document the `target` column in README and data schema docs
- add validation for missing or NaN target column

## Testing
- `bash ./run_full_integration_tests.sh`

------
https://chatgpt.com/codex/tasks/task_e_686ba684e88c8330931664534e21b49c