### PR TITLE
Add async IB connection

### DIFF
--- a/src/data_providers/standalone_provider.py
+++ b/src/data_providers/standalone_provider.py
@@ -55,7 +55,9 @@ class StandaloneDataProvider(BaseDataProvider):
         """Connect to IBKR using the shared connection manager."""
         try:
             manager = IBConnectionManager.instance()
-            self.ib = manager.connect(self.ib_host, self.ib_port, self.client_id)
+            self.ib = await manager.connect_async(
+                self.ib_host, self.ib_port, self.client_id
+            )
 
             def error_handler(reqId, errorCode, errorString, contract):
                 if errorCode == 354:


### PR DESCRIPTION
## Summary
- implement `IBConnectionManager.connect_async` to establish IBKR connections asynchronously
- update `StandaloneDataProvider.connect` to use the new async method
- guard connection attempts with an `asyncio.Lock`
- run integration tests to verify changes

## Testing
- `bash ./run_full_integration_tests.sh`
- `./run_realtime_api.sh` *(fails to connect to IBKR but no event loop/clientId errors)*

------
https://chatgpt.com/codex/tasks/task_e_686be5c1b5248330b7ff0adce820357c