### PR TITLE
Fix feature mismatch and cancel errors

### DIFF
--- a/tests/test_hierarchical_predictor.py
+++ b/tests/test_hierarchical_predictor.py
@@ -1,3 +1,4 @@
+import numpy as np
 from src.models.hierarchical_predictor import HierarchicalPredictor
 
 class DummyModel:
@@ -5,6 +6,16 @@ class DummyModel:
         self.value = value
     def predict_proba(self, X):
         return [[1 - self.value, self.value] for _ in range(len(X))]
+
+
+class FeatureLimitedModel(DummyModel):
+    def __init__(self, value: float, n_features: int):
+        super().__init__(value)
+        self.n_features_in_ = n_features
+
+    def predict_proba(self, X):
+        assert len(X[0]) == self.n_features_in_
+        return super().predict_proba(X)
 
 def test_hierarchy_fallback():
     predictor = HierarchicalPredictor()
@@ -17,3 +28,15 @@ def test_hierarchy_fallback():
     assert predictor.predict_proba("SPX", "Vertical", [[0]])[0][1] == 0.6
     assert predictor.predict_proba("XSP", "Butterfly", [[0]])[0][1] == 0.4
     assert predictor.predict_proba("QQQ", "Vertical", [[0]])[0][1] == 0.2
+
+
+def test_feature_truncation_warning(caplog):
+    predictor = HierarchicalPredictor()
+    predictor.symbol_strategy_models = {"SPX_Butterfly": FeatureLimitedModel(0.7, 31)}
+
+    X = [[0] * 85]
+    with caplog.at_level("WARNING"):
+        proba = predictor.predict_proba("SPX", "Butterfly", np.array(X))[0][1]
+        assert "Feature mismatch for SPX_Butterfly" in caplog.text
+    assert proba == 0.7
+

--- a/tests/test_provider_cancellation.py
+++ b/tests/test_provider_cancellation.py
@@ -1,0 +1,38 @@
+import pytest
+
+from src.data_providers.standalone_provider import StandaloneDataProvider
+
+
+class FakeTicker:
+    def __init__(self):
+        self.last = 100.0
+        self.close = None
+        self.bid = 99.5
+        self.ask = 100.5
+        self.bidSize = 1
+        self.askSize = 1
+
+
+class FakeIB:
+    def __init__(self):
+        self.cancel_called = False
+
+    def isConnected(self):
+        return True
+
+    def reqMktData(self, contract, *args):
+        return FakeTicker()
+
+    def cancelMktData(self, ticker):
+        self.cancel_called = True
+        raise Exception("No reqId found")
+
+
+@pytest.mark.asyncio
+async def test_cancel_mkt_data_handled():
+    provider = StandaloneDataProvider()
+    provider.ib = FakeIB()
+    result = await provider.get_current_price("SPX")
+    assert result["symbol"] == "SPX"
+    assert provider.ib.cancel_called
+


### PR DESCRIPTION
## Summary
- handle mismatched feature counts in `HierarchicalPredictor`
- guard market data cancellation in `StandaloneDataProvider`
- test feature truncation behaviour
- test safe handling of cancel errors

## Testing
- `bash ./run_full_integration_tests.sh`
- `pytest tests/test_hierarchical_predictor.py -v`
- `pytest tests/test_provider_cancellation.py -v`

------
https://chatgpt.com/codex/tasks/task_e_686d6141ad208330b2ddc1ccc808a6a2